### PR TITLE
[PF] Set the coupled term for the secondary variable caculation

### DIFF
--- a/ProcessLib/UncoupledProcessesTimeLoop.cpp
+++ b/ProcessLib/UncoupledProcessesTimeLoop.cpp
@@ -994,6 +994,11 @@ bool UncoupledProcessesTimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
         auto& pcs = spd->process;
         auto& x = *_process_solutions[pcs_idx];
         pcs.postTimestep(x);
+        StaggeredCouplingTerm coupling_term(
+            spd->coupled_processes,
+            _solutions_of_coupled_processes[pcs_idx], 0.0);
+        spd->process.setStaggeredCouplingTerm(&coupling_term);
+
         pcs.computeSecondaryVariable(t, x);
 
         ++pcs_idx;


### PR DESCRIPTION
as titled.

Another suggestion: remove the overloading of  voidProcess::computeSecondaryVariableConcrete in class  PhaseFieldStaggeredProces because it calls an empty function in the current implementation.